### PR TITLE
Fix int-backed enum defaults in generated form initial values

### DIFF
--- a/src/InertiaFormGenerator.php
+++ b/src/InertiaFormGenerator.php
@@ -612,6 +612,11 @@ class InertiaFormGenerator
                 }
 
                 $firstValue = $cases[0]->value;
+
+                if (is_int($firstValue)) {
+                    return (string) $firstValue;
+                }
+
                 // replace any \ with \\
                 $firstValue = str_replace('\\', '\\\\', $firstValue);
 

--- a/tests/Fixtures/Enums/Version.php
+++ b/tests/Fixtures/Enums/Version.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace RobTesch\InertiaFormGenerator\Tests\Fixtures\Enums;
+
+enum Version: int
+{
+    case VALUE_A = 1;
+    case VALUE_B = 2;
+}

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -8,6 +8,7 @@ use Illuminate\Validation\Rule;
 use InvalidArgumentException;
 use RobTesch\InertiaFormGenerator\InertiaFormGenerator;
 use RobTesch\InertiaFormGenerator\Tests\Fixtures\Enums\Status;
+use RobTesch\InertiaFormGenerator\Tests\Fixtures\Enums\Version;
 
 it('maps basic validation rules to types and initial values', function () {
     $generator = new InertiaFormGenerator;
@@ -103,7 +104,31 @@ it('maps Enum rule to a referenced enum type in the emitted type', function () {
     $item = $transformed[0];
 
     // the generated TS type should reference the enum type name (dot-separated)
-    expect($item['initial'])->toContain('status')->toContain('active');
+    expect($item['initial'])->toContain('status')->toContain("'active'");
+});
+
+it('maps int-backed Enum rule to an unquoted numeric default', function () {
+    $generator = new InertiaFormGenerator;
+
+    $request = new class extends FormRequest
+    {
+        public function rules(): array
+        {
+            return [
+                'version' => Rule::enum(Version::class),
+            ];
+        }
+    };
+
+    $transformed = $generator->transformRequests([$request]);
+
+    expect(count($transformed))->toBe(1);
+
+    $item = $transformed[0];
+
+    expect($item['initial'])->toContain('version: 1')
+        ->not->toContain("'1'")
+        ->not->toContain('"1"');
 });
 
 it('respects custom mappings from configuration', function () {


### PR DESCRIPTION
## Summary

- Emit unquoted numeric literals (e.g. `1`) instead of quoted strings (e.g. `'1'`) when generating defaults for int-backed PHP enums in form request output
- Add `Version` int-backed enum fixture and regression test
- Tighten string-backed enum test to assert quoted `'active'` default

Fixes #8

## Test plan

- [x] `composer test`
- [x] `composer format`
- [x] `composer analyse`